### PR TITLE
Fix incompatible pointer warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ wasm
 x64
 build/wajicup.js
 docs/yarnspin.html
+*.swo
+*.swp

--- a/source/audioconv.h
+++ b/source/audioconv.h
@@ -23,7 +23,7 @@ qoa_data_t* convert_audio( string audio_filename ) {
         if( !short_samples ) {
             uint32_t wav_channels = 0;
             uint32_t wav_sample_rate = 0;
-            uint64_t wav_sample_count = 0;
+            drwav_uint64 wav_sample_count = 0;
             short_samples = drwav_open_file_and_read_pcm_frames_s16( audio_filename, &wav_channels, &wav_sample_rate, &wav_sample_count, NULL );
             channels = (int) wav_channels;
             sample_rate = (int) wav_sample_rate;
@@ -40,7 +40,7 @@ qoa_data_t* convert_audio( string audio_filename ) {
         if( !short_samples ) {
             uint32_t flac_channels = 0;
             uint32_t flac_sample_rate = 0;
-            uint64_t flac_sample_count = 0;
+            drwav_uint64 flac_sample_count = 0;
             short_samples = drflac_open_file_and_read_pcm_frames_s16( audio_filename, &flac_channels, &flac_sample_rate, &flac_sample_count, NULL );
             channels = (int) flac_channels;
             sample_rate = (int) flac_sample_rate;
@@ -57,7 +57,7 @@ qoa_data_t* convert_audio( string audio_filename ) {
         if( !short_samples ) {
             uint32_t mp3_channels = 0;
             uint32_t mp3_sample_rate = 0;
-            uint64_t mp3_sample_count = 0;
+            drwav_uint64 mp3_sample_count = 0;
             drmp3_config mp3_config = { 0, 0 };
             short_samples = drmp3_open_file_and_read_pcm_frames_s16( audio_filename, &mp3_config, &mp3_sample_count, NULL );
             channels = (int) mp3_config.channels;


### PR DESCRIPTION
All 3 of my compilers (tcc,gcc,clang) would complain about incompatible pointer types in the audioconv file, and without any warning flags turned on. Trivial fix.

```
In file included from ../source/yarnspin.c:186:
../source/audioconv.h:27:119: warning: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long *') to parameter of type 'drwav_uint64 *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
            short_samples = drwav_open_file_and_read_pcm_frames_s16( audio_filename, &wav_channels, &wav_sample_rate, &wav_sample_count, NULL );
                                                                                                                      ^~~~~~~~~~~~~~~~~
../source/libs/dr_wav.h:1251:156: note: passing argument to parameter 'totalFrameCountOut' here
DRWAV_API drwav_int16* drwav_open_file_and_read_pcm_frames_s16(const char* filename, unsigned int* channelsOut, unsigned int* sampleRateOut, drwav_uint64* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks);
                                                                                                                                                           ^
In file included from ../source/yarnspin.c:186:
../source/audioconv.h:44:122: warning: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long *') to parameter of type 'drflac_uint64 *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
            short_samples = drflac_open_file_and_read_pcm_frames_s16( audio_filename, &flac_channels, &flac_sample_rate, &flac_sample_count, NULL );
                                                                                                                         ^~~~~~~~~~~~~~~~~~
../source/libs/dr_flac.h:1234:154: note: passing argument to parameter 'totalPCMFrameCount' here
DRFLAC_API drflac_int16* drflac_open_file_and_read_pcm_frames_s16(const char* filename, unsigned int* channels, unsigned int* sampleRate, drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
                                                                                                                                                         ^
In file included from ../source/yarnspin.c:186:
../source/audioconv.h:62:99: warning: incompatible pointer types passing 'uint64_t *' (aka 'unsigned long *') to parameter of type 'drmp3_uint64 *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
            short_samples = drmp3_open_file_and_read_pcm_frames_s16( audio_filename, &mp3_config, &mp3_sample_count, NULL );
                                                                                                  ^~~~~~~~~~~~~~~~~
../source/libs/dr_mp3.h:497:123: note: passing argument to parameter 'pTotalFrameCount' here
DRMP3_API drmp3_int16* drmp3_open_file_and_read_pcm_frames_s16(const char* filePath, drmp3_config* pConfig, drmp3_uint64* pTotalFrameCount, const drmp3_allocation_callbacks* pAllocationCallbacks);
                                                                                                                          ^
3 warnings generated.
```